### PR TITLE
fix: configure Cognito environment variables in CI/CD pipeline

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -41,6 +41,8 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     needs: test-and-lint
+    outputs:
+      cognito-configured: ${{ steps.get-cognito.outputs.COGNITO_CONFIGURED }}
 
     steps:
       - name: Checkout code
@@ -55,8 +57,50 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Cognito configuration from existing stack
+        id: get-cognito
+        run: |
+          # Try to get Cognito IDs from existing stack if it exists
+          STACK_EXISTS=$(aws cloudformation describe-stacks --stack-name fitnessfight-club-${{ env.ENVIRONMENT }}-Stack --query "Stacks[0].StackName" --output text 2>/dev/null || echo "")
+
+          if [ -n "$STACK_EXISTS" ]; then
+            echo "Getting Cognito configuration from existing stack..."
+            USER_POOL_ID=$(aws cloudformation describe-stacks \
+              --stack-name fitnessfight-club-${{ env.ENVIRONMENT }}-Stack \
+              --query "Stacks[0].Outputs[?OutputKey=='CognitoUserPoolId'].OutputValue" \
+              --output text)
+            USER_POOL_CLIENT_ID=$(aws cloudformation describe-stacks \
+              --stack-name fitnessfight-club-${{ env.ENVIRONMENT }}-Stack \
+              --query "Stacks[0].Outputs[?OutputKey=='AuthUserPoolClientId8216BF9A'].OutputValue" \
+              --output text)
+            echo "USER_POOL_ID=$USER_POOL_ID" >> $GITHUB_OUTPUT
+            echo "USER_POOL_CLIENT_ID=$USER_POOL_CLIENT_ID" >> $GITHUB_OUTPUT
+            echo "COGNITO_CONFIGURED=true" >> $GITHUB_OUTPUT
+            echo "Found User Pool ID: $USER_POOL_ID"
+            echo "Found Client ID: $USER_POOL_CLIENT_ID"
+          else
+            echo "Stack not found, using placeholder values (will be updated after deployment)"
+            echo "USER_POOL_ID=placeholder" >> $GITHUB_OUTPUT
+            echo "USER_POOL_CLIENT_ID=placeholder" >> $GITHUB_OUTPUT
+            echo "COGNITO_CONFIGURED=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build frontend
-        run: npm run build --workspace=frontend
+        env:
+          NEXT_PUBLIC_USER_POOL_ID: ${{ steps.get-cognito.outputs.USER_POOL_ID }}
+          NEXT_PUBLIC_USER_POOL_CLIENT_ID: ${{ steps.get-cognito.outputs.USER_POOL_CLIENT_ID }}
+        run: |
+          echo "Building with Cognito configuration:"
+          echo "USER_POOL_ID: $NEXT_PUBLIC_USER_POOL_ID"
+          echo "CLIENT_ID: $NEXT_PUBLIC_USER_POOL_CLIENT_ID"
+          npm run build --workspace=frontend
 
       - name: Upload frontend artifacts
         uses: actions/upload-artifact@v4
@@ -108,6 +152,52 @@ jobs:
         run: |
           cd infrastructure
           npm run deploy:dev
+
+      - name: Check if frontend needs rebuild
+        id: check-rebuild
+        run: |
+          # Get the actual Cognito IDs from the deployed stack
+          ACTUAL_USER_POOL_ID=$(aws cloudformation describe-stacks \
+            --stack-name fitnessfight-club-${{ env.ENVIRONMENT }}-Stack \
+            --query "Stacks[0].Outputs[?OutputKey=='CognitoUserPoolId'].OutputValue" \
+            --output text)
+          ACTUAL_CLIENT_ID=$(aws cloudformation describe-stacks \
+            --stack-name fitnessfight-club-${{ env.ENVIRONMENT }}-Stack \
+            --query "Stacks[0].Outputs[?OutputKey=='AuthUserPoolClientId8216BF9A'].OutputValue" \
+            --output text)
+
+          # Check if frontend was built with placeholder values
+          if [ "${{ needs.build-frontend.outputs.cognito-configured }}" = "false" ]; then
+            echo "Frontend needs rebuild with actual Cognito IDs"
+            echo "NEEDS_REBUILD=true" >> $GITHUB_OUTPUT
+            echo "USER_POOL_ID=$ACTUAL_USER_POOL_ID" >> $GITHUB_OUTPUT
+            echo "CLIENT_ID=$ACTUAL_CLIENT_ID" >> $GITHUB_OUTPUT
+          else
+            echo "Frontend already built with correct Cognito IDs"
+            echo "NEEDS_REBUILD=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Rebuild frontend with Cognito configuration
+        if: steps.check-rebuild.outputs.NEEDS_REBUILD == 'true'
+        env:
+          NEXT_PUBLIC_USER_POOL_ID: ${{ steps.check-rebuild.outputs.USER_POOL_ID }}
+          NEXT_PUBLIC_USER_POOL_CLIENT_ID: ${{ steps.check-rebuild.outputs.CLIENT_ID }}
+        run: |
+          echo "Rebuilding frontend with actual Cognito configuration..."
+          echo "USER_POOL_ID: $NEXT_PUBLIC_USER_POOL_ID"
+          echo "CLIENT_ID: $NEXT_PUBLIC_USER_POOL_CLIENT_ID"
+          npm run build --workspace=frontend
+
+          # Upload the rebuilt frontend to S3
+          aws s3 sync frontend/out/ s3://fitnessfight-club-frontend-${{ env.ENVIRONMENT }}/ --delete
+
+          # Invalidate CloudFront cache
+          DISTRIBUTION_ID=$(aws cloudformation describe-stacks \
+            --stack-name fitnessfight-club-${{ env.ENVIRONMENT }}-Stack \
+            --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
+            --output text)
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
+          echo "Frontend rebuilt and deployed with correct Cognito configuration"
 
       - name: Setup Strava webhook subscription
         run: |

--- a/scripts/rebuild-frontend.sh
+++ b/scripts/rebuild-frontend.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Script to rebuild frontend with Cognito configuration
+# Usage: ./scripts/rebuild-frontend.sh [dev|prod]
+
+ENVIRONMENT=${1:-dev}
+STACK_NAME="fitnessfight-club-${ENVIRONMENT}-Stack"
+
+echo "Rebuilding frontend for environment: $ENVIRONMENT"
+
+# Get Cognito IDs from deployed stack
+echo "Getting Cognito configuration from CloudFormation..."
+USER_POOL_ID=$(aws cloudformation describe-stacks \
+  --stack-name $STACK_NAME \
+  --query "Stacks[0].Outputs[?OutputKey=='CognitoUserPoolId'].OutputValue" \
+  --output text \
+  --region us-east-1)
+
+CLIENT_ID=$(aws cloudformation describe-stacks \
+  --stack-name $STACK_NAME \
+  --query "Stacks[0].Outputs[?OutputKey=='AuthUserPoolClientId8216BF9A'].OutputValue" \
+  --output text \
+  --region us-east-1)
+
+echo "User Pool ID: $USER_POOL_ID"
+echo "Client ID: $CLIENT_ID"
+
+if [ -z "$USER_POOL_ID" ] || [ -z "$CLIENT_ID" ]; then
+  echo "Error: Could not get Cognito configuration from stack"
+  exit 1
+fi
+
+# Build frontend with Cognito configuration
+echo "Building frontend with Cognito configuration..."
+cd frontend
+NEXT_PUBLIC_USER_POOL_ID=$USER_POOL_ID \
+NEXT_PUBLIC_USER_POOL_CLIENT_ID=$CLIENT_ID \
+npm run build
+
+# Upload to S3
+echo "Uploading to S3..."
+aws s3 sync out/ s3://fitnessfight-club-frontend-${ENVIRONMENT}/ --delete --region us-east-1
+
+# Get CloudFront distribution ID
+DISTRIBUTION_ID=$(aws cloudformation describe-stacks \
+  --stack-name $STACK_NAME \
+  --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
+  --output text \
+  --region us-east-1)
+
+# Invalidate CloudFront cache
+if [ -n "$DISTRIBUTION_ID" ]; then
+  echo "Invalidating CloudFront cache (Distribution: $DISTRIBUTION_ID)..."
+  aws cloudfront create-invalidation \
+    --distribution-id $DISTRIBUTION_ID \
+    --paths "/*" \
+    --region us-east-1
+fi
+
+echo "Frontend rebuilt and deployed successfully!"
+echo "Visit: https://$(aws cloudformation describe-stacks \
+  --stack-name $STACK_NAME \
+  --query "Stacks[0].Outputs[?OutputKey=='CloudFrontURL'].OutputValue" \
+  --output text \
+  --region us-east-1)"


### PR DESCRIPTION
- Add step to get Cognito IDs from existing stack before building frontend
- Pass Cognito configuration as environment variables during build
- Add automatic rebuild if frontend was built without Cognito config
- Create rebuild-frontend.sh script for manual rebuilds
- Ensure authentication works in deployed environments

This fixes the 'Cognito configuration missing' error in production.