### PR TITLE
fix: correct Button/Link component nesting for Next.js 13+

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -110,12 +110,12 @@ function HomeContent() {
             <div className="text-center space-y-4">
               <p className="text-muted-foreground">Please sign in to connect your Strava account</p>
               <div className="flex items-center justify-center space-x-4">
-                <Link href="/signin">
-                  <Button variant="outline">Sign In</Button>
-                </Link>
-                <Link href="/signup">
-                  <Button>Sign Up</Button>
-                </Link>
+                <Button variant="outline" asChild>
+                  <Link href="/signin">Sign In</Link>
+                </Button>
+                <Button asChild>
+                  <Link href="/signup">Sign Up</Link>
+                </Button>
               </div>
             </div>
           )}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -98,14 +98,12 @@ export function Header() {
               </div>
             ) : (
               <div className="flex items-center space-x-2">
-                <Link href="/signin">
-                  <Button variant="ghost" size="sm">
-                    Sign In
-                  </Button>
-                </Link>
-                <Link href="/signup">
-                  <Button size="sm">Sign Up</Button>
-                </Link>
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href="/signin">Sign In</Link>
+                </Button>
+                <Button size="sm" asChild>
+                  <Link href="/signup">Sign Up</Link>
+                </Button>
               </div>
             )}
           </div>


### PR DESCRIPTION
- Use asChild prop on Button components when wrapping Link
- Fix navigation buttons in header and homepage
- Resolves issue where Sign Up/Sign In buttons were not clickable

In Next.js 13+, Link components don't automatically pass click handlers to child components. Using asChild prop makes Button render as Link properly.