### PR TITLE
fix: password validation message and auth state management

### DIFF
--- a/frontend/__tests__/app/signin/page.test.tsx
+++ b/frontend/__tests__/app/signin/page.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import SignInPage from '@/app/signin/page'
+import { AuthProvider } from '@/components/auth-provider'
 
 // Mock dependencies
 jest.mock('@/lib/auth', () => ({
   signIn: jest.fn(),
+  getCurrentUser: jest.fn(() => Promise.resolve(null)),
 }))
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({ push: jest.fn() })),
@@ -24,12 +26,20 @@ describe('SignIn Page', () => {
   })
 
   it('should render sign in page', () => {
-    render(<SignInPage />)
+    render(
+      <AuthProvider>
+        <SignInPage />
+      </AuthProvider>
+    )
     expect(screen.getByText('Sign in to your account')).toBeInTheDocument()
   })
 
   it('should have sign up link', () => {
-    render(<SignInPage />)
+    render(
+      <AuthProvider>
+        <SignInPage />
+      </AuthProvider>
+    )
     expect(screen.getByText(/Don't have an account/)).toBeInTheDocument()
   })
 })

--- a/frontend/__tests__/components/header.test.tsx
+++ b/frontend/__tests__/components/header.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Header } from '@/components/header'
+import { AuthProvider } from '@/components/auth-provider'
 import { signOut, getCurrentUser } from '@/lib/auth'
 import { useRouter } from 'next/navigation'
 
@@ -33,7 +34,11 @@ describe('Header Component', () => {
     })
 
     it('should render logo and title', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.getByText('Fitness Fight Club')).toBeInTheDocument()
@@ -41,7 +46,11 @@ describe('Header Component', () => {
     })
 
     it('should show Sign In and Sign Up buttons when not authenticated', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.getByText('Sign In')).toBeInTheDocument()
@@ -50,7 +59,11 @@ describe('Header Component', () => {
     })
 
     it('should not show navigation links when not authenticated', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
@@ -60,7 +73,11 @@ describe('Header Component', () => {
     })
 
     it('should not show user email or Sign Out button', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.queryByText('Sign Out')).not.toBeInTheDocument()
@@ -81,7 +98,11 @@ describe('Header Component', () => {
     })
 
     it('should show navigation links when authenticated', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.getByText('Dashboard')).toBeInTheDocument()
@@ -91,7 +112,11 @@ describe('Header Component', () => {
     })
 
     it('should show user email when authenticated', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.getByText('test@example.com')).toBeInTheDocument()
@@ -99,7 +124,11 @@ describe('Header Component', () => {
     })
 
     it('should show Sign Out button when authenticated', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.getByText('Sign Out')).toBeInTheDocument()
@@ -107,7 +136,11 @@ describe('Header Component', () => {
     })
 
     it('should not show Sign In and Sign Up buttons when authenticated', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         expect(screen.queryByText('Sign In')).not.toBeInTheDocument()
@@ -118,7 +151,11 @@ describe('Header Component', () => {
     it('should handle sign out when Sign Out button is clicked', async () => {
       ;(signOut as jest.Mock).mockResolvedValue({ success: true })
 
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       // Wait for the component to finish loading
       await waitFor(() => {
@@ -142,7 +179,11 @@ describe('Header Component', () => {
       })
       jest.spyOn(console, 'error').mockImplementation(() => {})
 
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       // Wait for the component to finish loading
       await waitFor(() => {
@@ -168,7 +209,11 @@ describe('Header Component', () => {
     it('should show loading state initially', () => {
       ;(getCurrentUser as jest.Mock).mockImplementation(() => new Promise(() => {}))
 
-      const { container } = render(<Header />)
+      const { container } = render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       // Should show loading skeleton
       expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
@@ -187,7 +232,11 @@ describe('Header Component', () => {
     })
 
     it('should render correct href for navigation links', async () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         const dashboardLink = screen.getByText('Dashboard').closest('a')
@@ -203,7 +252,11 @@ describe('Header Component', () => {
     it('should render correct href for auth buttons', async () => {
       ;(getCurrentUser as jest.Mock).mockRejectedValue(new Error('Not authenticated'))
 
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       await waitFor(() => {
         const signInLink = screen.getByText('Sign In').closest('a')
@@ -217,14 +270,22 @@ describe('Header Component', () => {
 
   describe('Responsive Behavior', () => {
     it('should have fixed positioning classes', () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       const header = screen.getByRole('banner')
       expect(header).toHaveClass('fixed', 'top-0', 'left-0', 'right-0', 'z-50')
     })
 
     it('should have proper styling classes', () => {
-      render(<Header />)
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      )
 
       const header = screen.getByRole('banner')
       expect(header).toHaveClass('border-b')

--- a/frontend/app/signin/page.tsx
+++ b/frontend/app/signin/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { SignInForm } from '@/components/auth-forms'
 import { signIn } from '@/lib/auth'
+import { useAuth } from '@/components/auth-provider'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,6 +15,7 @@ function SignInContent() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { refreshUser } = useAuth()
 
   useEffect(() => {
     // Check if user just confirmed their email
@@ -34,6 +36,8 @@ function SignInContent() {
     const result = await signIn(data)
 
     if (result.success) {
+      // Refresh auth state before redirecting
+      await refreshUser()
       // Redirect to home page or return URL
       const returnUrl = searchParams?.get('returnUrl') || '/'
       router.push(returnUrl)

--- a/frontend/components/auth-forms.tsx
+++ b/frontend/components/auth-forms.tsx
@@ -36,9 +36,17 @@ export function SignUpForm({
       errors.email = 'Please enter a valid email address'
     }
 
-    // Validate password - only check length
+    // Validate password - check all requirements
     if (formData.password.length < 8) {
       errors.password = 'Password must be at least 8 characters'
+    } else if (
+      !(
+        /[a-z]/.test(formData.password) &&
+        /[A-Z]/.test(formData.password) &&
+        /[0-9]/.test(formData.password)
+      )
+    ) {
+      errors.password = 'Password must contain uppercase, lowercase, and numbers'
     }
 
     // Validate name
@@ -110,7 +118,9 @@ export function SignUpForm({
           onChange={(e) => setFormData({ ...formData, password: e.target.value })}
           disabled={loading}
         />
-        <p className="mt-1 text-xs text-gray-500">Must be at least 8 characters</p>
+        <p className="mt-1 text-xs text-gray-500">
+          Must be at least 8 characters with uppercase, lowercase, and numbers
+        </p>
       </div>
 
       {error && <div className="p-3 text-sm text-red-600 bg-red-50 rounded-md">{error}</div>}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -1,44 +1,20 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { signOut } from '@/lib/auth'
-import { getCurrentUser } from '@/lib/auth'
+import { useAuth } from '@/components/auth-provider'
 import { LogOut, User } from 'lucide-react'
 
 export function Header() {
-  const [user, setUser] = useState<{ username: string; email?: string } | null>(null)
-  const [loading, setLoading] = useState(true)
+  const { user, loading, refreshUser } = useAuth()
   const router = useRouter()
-
-  useEffect(() => {
-    checkUser()
-  }, [])
-
-  async function checkUser() {
-    try {
-      const currentUser = await getCurrentUser()
-      if (currentUser) {
-        setUser({
-          username: currentUser.username,
-          email: currentUser.email,
-        })
-      } else {
-        setUser(null)
-      }
-    } catch {
-      setUser(null)
-    } finally {
-      setLoading(false)
-    }
-  }
 
   async function handleSignOut() {
     const result = await signOut()
     if (result.success) {
-      setUser(null)
+      await refreshUser()
       router.push('/')
       router.refresh()
     }


### PR DESCRIPTION
- Update password validation to show all Cognito requirements (uppercase, lowercase, digits)
- Fix auth state not updating after sign-in by using AuthProvider consistently
- Header now uses AuthProvider instead of its own state
- Sign-in page refreshes auth state after successful login
- Update tests to wrap components with AuthProvider

This fixes the issues where:
- Password field showed only '8 characters' but Cognito requires more
- After sign-in, user remained unauthenticated in UI
- Connect with Strava button wasn't showing for logged-in users