### PR TITLE
fix: Lambda deployment missing dependencies causing 502 errors

### DIFF
--- a/infrastructure/lambda/api/index.js
+++ b/infrastructure/lambda/api/index.js
@@ -203,11 +203,17 @@ exports.handler = async (event) => {
 
   const { httpMethod, path, pathParameters, queryStringParameters, body, headers } = event
 
+  // Determine allowed origin based on environment
+  const allowedOrigin = process.env.ENVIRONMENT === 'prod' 
+    ? 'https://fitnessfight.club'
+    : 'https://dev.fitnessfight.club'
+  
   // CORS headers
   const corsHeaders = {
-    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Origin': allowedOrigin,
     'Access-Control-Allow-Headers': 'Content-Type,Authorization',
     'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Credentials': 'true',
   }
 
   // Handle health check

--- a/infrastructure/lib/api-stack.ts
+++ b/infrastructure/lib/api-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import * as apigateway from 'aws-cdk-lib/aws-apigateway'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as cognito from 'aws-cdk-lib/aws-cognito'
@@ -22,7 +23,7 @@ export interface ApiStackProps {
 
 export class ApiStack extends Construct {
   public readonly api: apigateway.RestApi
-  public readonly apiFunction: lambda.Function
+  public readonly apiFunction: NodejsFunction
   public readonly webhookVerifyToken: string
 
   constructor(scope: Construct, id: string, props: ApiStackProps) {
@@ -61,12 +62,24 @@ export class ApiStack extends Construct {
     // Generate a secure webhook verification token
     this.webhookVerifyToken = `fitnessfight-webhook-${environment}-${Math.random().toString(36).substring(2, 15)}`
 
-    // Create Lambda function for API
-    this.apiFunction = new lambda.Function(this, 'ApiFunction', {
+    // Create Lambda function for API with bundled dependencies
+    this.apiFunction = new NodejsFunction(this, 'ApiFunction', {
       functionName: `fitnessfight-club-api-${environment}`,
       runtime: lambda.Runtime.NODEJS_20_X,
-      handler: 'index.handler',
-      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/api')),
+      handler: 'handler',
+      entry: path.join(__dirname, '../lambda/api/index.js'),
+      depsLockFilePath: path.join(__dirname, '../lambda/api/package-lock.json'),
+      bundling: {
+        minify: false, // Keep readable for debugging
+        sourceMap: false, // Disable source maps for now
+        forceDockerBundling: false,
+        nodeModules: [
+          'aws-jwt-verify',
+          '@aws-sdk/client-dynamodb',
+          '@aws-sdk/lib-dynamodb',
+          '@aws-sdk/client-secrets-manager',
+        ],
+      },
       environment: {
         ENVIRONMENT: environment,
         USERS_TABLE: usersTable.tableName,


### PR DESCRIPTION
- Switch from lambda.Function to NodejsFunction for automatic bundling
- Include aws-jwt-verify and AWS SDK dependencies in bundle
- Fix CORS headers to use specific origin instead of wildcard
- Add credentials support to CORS headers

This fixes the 'Connect with Strava' button failing with CORS errors and 502 responses