### PR TITLE
fix: persist auth state across page redirects and show Strava connect…

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button'
 
 function HomeContent() {
   const searchParams = useSearchParams()
-  const { user, loading: authLoading } = useAuth()
+  const { user, loading: authLoading, refreshUser } = useAuth()
   const [statusMessage, setStatusMessage] = useState<{
     type: 'success' | 'error'
     message: string
@@ -30,6 +30,9 @@ function HomeContent() {
       })
       // Clean URL after showing message
       window.history.replaceState({}, '', '/')
+
+      // Refresh auth state to ensure we're still logged in
+      refreshUser()
 
       // Auto-dismiss message after 5 seconds
       timer = setTimeout(() => {

--- a/frontend/components/strava-connect-button.tsx
+++ b/frontend/components/strava-connect-button.tsx
@@ -1,12 +1,48 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { getConfig } from '@/lib/config'
 import { getAuthTokens } from '@/lib/cognito-client'
 
 export function StravaConnectButton() {
   const [isLoading, setIsLoading] = useState(false)
+  const [isConnected, setIsConnected] = useState(false)
+  const [checkingStatus, setCheckingStatus] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  // Check if Strava is already connected on mount
+  useEffect(() => {
+    checkStravaConnection()
+  }, [])
+
+  const checkStravaConnection = async () => {
+    try {
+      const config = getConfig()
+      const tokens = getAuthTokens()
+      const token = tokens.IdToken
+
+      if (!token) {
+        setCheckingStatus(false)
+        return
+      }
+
+      // Check connection status
+      const response = await fetch(`${config.apiUrl}/auth/strava`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        setIsConnected(data.stravaConnected || false)
+      }
+    } catch (err) {
+      console.error('Error checking Strava connection:', err)
+    } finally {
+      setCheckingStatus(false)
+    }
+  }
 
   const handleConnect = async () => {
     setIsLoading(true)
@@ -43,7 +79,7 @@ export function StravaConnectButton() {
 
       // Check if Strava is already connected
       if (data.stravaConnected) {
-        setError('Your Strava account is already connected!')
+        setIsConnected(true)
         setIsLoading(false)
         return
       }
@@ -59,6 +95,28 @@ export function StravaConnectButton() {
       setError('Failed to connect to Strava. Please try again.')
       setIsLoading(false)
     }
+  }
+
+  if (checkingStatus) {
+    return (
+      <div className="flex items-center justify-center">
+        <div className="h-12 w-48 bg-muted animate-pulse rounded-md" />
+      </div>
+    )
+  }
+
+  if (isConnected) {
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <div className="bg-green-100 text-green-800 border border-green-300 font-bold py-3 px-6 rounded-lg flex items-center gap-3">
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+          </svg>
+          <span>Strava Connected</span>
+        </div>
+        <p className="text-sm text-muted-foreground">Your activities are being tracked</p>
+      </div>
+    )
   }
 
   return (

--- a/frontend/lib/cognito-client.ts
+++ b/frontend/lib/cognito-client.ts
@@ -14,22 +14,53 @@ export const cognitoClient = new CognitoIdentityProviderClient({
 })
 
 // Store tokens in memory (you might want to use localStorage or cookies in production)
-let authTokens: {
+const TOKEN_STORAGE_KEY = 'fitnessfight_auth_tokens'
+
+interface AuthTokens {
   AccessToken?: string
   IdToken?: string
   RefreshToken?: string
-} = {}
-
-export function getAuthTokens() {
-  return authTokens
 }
 
-export function setAuthTokens(tokens: typeof authTokens) {
-  authTokens = tokens
+export function getAuthTokens(): AuthTokens {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  try {
+    const stored = localStorage.getItem(TOKEN_STORAGE_KEY)
+    if (stored) {
+      return JSON.parse(stored)
+    }
+  } catch (err) {
+    console.error('Error reading auth tokens:', err)
+  }
+
+  return {}
+}
+
+export function setAuthTokens(tokens: AuthTokens) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens))
+  } catch (err) {
+    console.error('Error storing auth tokens:', err)
+  }
 }
 
 export function clearAuthTokens() {
-  authTokens = {}
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    localStorage.removeItem(TOKEN_STORAGE_KEY)
+  } catch (err) {
+    console.error('Error clearing auth tokens:', err)
+  }
 }
 
 export { USER_POOL_ID, CLIENT_ID }


### PR DESCRIPTION
…ion status

- Store auth tokens in localStorage instead of memory
- Tokens now survive page redirects during OAuth flow
- Add Strava connection status check on button mount
- Show 'Strava Connected' state when already connected
- Refresh auth state after successful Strava connection
- Fix auth state persistence after OAuth callback

This fixes:
- Auth state being lost after Strava OAuth redirect
- Sign In/Sign Up buttons showing for logged-in users after OAuth
- Strava button not showing connection status