### PR TITLE
fix: use fullname attribute instead of name for Google identity provi…

### DIFF
--- a/infrastructure/lib/auth-stack.ts
+++ b/infrastructure/lib/auth-stack.ts
@@ -120,6 +120,7 @@ export class AuthStack extends Construct {
       clientSecretValue: googleClientSecretSecret.secretValue,
       attributeMapping: {
         email: cognito.ProviderAttribute.GOOGLE_EMAIL,
+        fullname: cognito.ProviderAttribute.GOOGLE_NAME,
         givenName: cognito.ProviderAttribute.GOOGLE_GIVEN_NAME,
         familyName: cognito.ProviderAttribute.GOOGLE_FAMILY_NAME,
         profilePicture: cognito.ProviderAttribute.GOOGLE_PICTURE,

--- a/infrastructure/test/fitnessfight-stack.test.ts
+++ b/infrastructure/test/fitnessfight-stack.test.ts
@@ -296,6 +296,7 @@ describe('FitnessFightStack', () => {
       ProviderType: 'Google',
       AttributeMapping: {
         email: 'email',
+        name: 'name',
         given_name: 'given_name',
         family_name: 'family_name',
         picture: 'picture',


### PR DESCRIPTION
…der [FC-8]

The Cognito Google identity provider requires a 'name' attribute mapping, but the CDK AttributeMapping interface uses 'fullname' for this purpose. Updated the attribute mapping to use fullname which correctly maps to the name attribute in CloudFormation.